### PR TITLE
remove recruitment and GPT-5.5 token sponsorship messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,9 +40,9 @@
                     </button>
                 </nav>
                 <section class="collab-callout" aria-labelledby="collab-title">
-                    <strong id="collab-title">开源协作招募</strong>
-                    <p>寻找活跃的开源贡献者，学生优先。我可以赞助 GPT-5.5 token：你可以用于自己的开源项目，也请用 GPT-5.5 帮我测试、调试、改进我的公开仓库。</p>
-                    <p>仅限非商业用途。需要项目经历、又缺少 token，欢迎联系互加微信。</p>
+                    <strong id="collab-title">开源支持</strong>
+                    <p>如果你觉得这些项目有帮助，欢迎通过加密消息留下赞助或支持信息。</p>
+                    <p>输入 <kbd>msg</kbd> 可发送加密联系内容。</p>
                 </section>
             </div>
             <div class="key-block">

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -23,7 +23,7 @@ export function commandDescription(name: string): string {
         skills: 'working areas',
         projects: 'recent repositories',
         stats: 'GitHub numbers',
-        sponsor: 'open-source token sponsorship',
+        sponsor: 'open-source support',
         contact: 'links and key',
         msg: 'encrypted message card',
         clear: 'clear scrollback',

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -686,9 +686,9 @@ const commands: Record<string, CommandHandler> = {
     sponsor: () => {
         writeLine(`
             <div class="panel-copy">
-                <strong>开源协作招募</strong>
-                <p>寻找活跃的开源贡献者，学生优先。我可以赞助 GPT-5.5 token：你可以用于自己的开源项目，也请用 GPT-5.5 帮我测试、调试、改进我的公开仓库。</p>
-                <p>仅限非商业用途。需要项目经历、又缺少 token，欢迎联系互加微信。</p>
+                <strong>开源支持</strong>
+                <p>如果你觉得这些项目有帮助，欢迎通过加密消息留下赞助或支持信息。</p>
+                <p>不再提供 GPT-5.5 token 赞助。</p>
                 <p class="muted">Type <kbd>msg</kbd> to send an encrypted contact note.</p>
             </div>
         `)
@@ -873,7 +873,7 @@ function bindChrome(): void {
 
 function boot(): void {
     writeLine('<pre class="hero-type">LIghtJUNction</pre>')
-    writeLine('Terminal app. PGP messages. Open-source token sponsorship. Type <kbd>sponsor</kbd> or <kbd>help</kbd>.', 'muted')
+    writeLine('Terminal app. PGP messages. Open-source support. Type <kbd>sponsor</kbd> or <kbd>help</kbd>.', 'muted')
 }
 
 applyRandomVisuals()


### PR DESCRIPTION
## Summary by Sourcery

更新站点和终端文案，以反映停止 GPT-5.5 代币赞助，转而采用通用的开源支持信息。

Enhancements:
- 修改 sponsor 命令面板文案，删除招募类语言和 GPT-5.5 代币赞助优惠，改为强调对开源的支持。
- 更新终端启动副标题，将“开源代币赞助”改为“开源支持”的描述。
- 调整首页协作提示内容，从“开源招募和代币赞助”改为推广“加密支持消息”。
- 更新 sponsor 命令描述，使其与新的开源支持措辞保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update site and terminal copy to reflect discontinuation of GPT-5.5 token sponsorship in favor of general open-source support messaging.

Enhancements:
- Revise sponsor command panel text to remove recruitment language and GPT-5.5 token sponsorship offer, emphasizing open-source support instead.
- Update terminal boot subtitle to describe 'open-source support' rather than 'open-source token sponsorship'.
- Adjust index page collaboration callout content to promote encrypted support messages instead of open-source recruitment and token sponsorship.
- Refresh sponsor command description to align with the new open-source support wording.

</details>